### PR TITLE
fix(runs): guard pvalue.match against null/empty bindings

### DIFF
--- a/src/screens/modeling/thread/mint-runs.ts
+++ b/src/screens/modeling/thread/mint-runs.ts
@@ -508,13 +508,17 @@ export class MintRuns extends connect(store)(MintThreadPage) {
                                         }
                                       })}
                                       ${grouped_ensemble.params.map((param) => {
-                                        let pvalue = ensemble.bindings[param.id]
-                                          ? ensemble.bindings[param.id]
-                                          : param_defaults[param.id];
-                                        if (pvalue.match(/^__region_geojson/)) {
+                                        let pvalue =
+                                          param.id in ensemble.bindings
+                                            ? ensemble.bindings[param.id]
+                                            : param_defaults[param.id];
+                                        if (
+                                          typeof pvalue === 'string' &&
+                                          pvalue.match(/^__region_geojson/)
+                                        ) {
                                           pvalue = 'Region Geojson';
                                         }
-                                        return html`<td>${pvalue}</td>`;
+                                        return html`<td>${pvalue ?? ''}</td>`;
                                       })}
                                     </tr>
                                   `;


### PR DESCRIPTION
## Summary
- Empty-string parameter bindings (\`parameter_value: \"\"\`) fell through the truthy ternary in \`params.map\` to a null default, causing \`pvalue.match(/^__region_geojson/)\` to throw mid-render.
- LitElement kept the previous frame in the DOM (the \`loading=true\` spinner), so users saw an indefinite circular spinner on the Runs page even though \`loading=false\` had already dispatched.
- Fix: use \`param.id in ensemble.bindings\` membership instead of a truthy ternary, guard \`.match\` with \`typeof pvalue === 'string'\`, and coalesce null/undefined to \`''\` in the rendered cell.

Reproducer: a model whose \`modelcatalog_parameter\` has no default, with an empty-string binding from the user. Captured in \`.wolf/buglog.json\` as bug-067 (related: bug-063, bug-011).

## Test plan
- [ ] Reload \`/runs\` for a thread with WAITING executions and empty-string parameter bindings — table renders, spinner clears.
- [ ] Confirm region-geojson sentinel still shows as \"Region Geojson\".
- [ ] No new TS diagnostics on \`mint-runs.ts\` lines we touched.