### PR TITLE
fix(thread): respect is_optional on dataset selection screen

### DIFF
--- a/src/queries/thread/get-subscription.graphql
+++ b/src/queries/thread/get-subscription.graphql
@@ -49,6 +49,7 @@ subscription sub_thread($id: String!) {
           }
         }
         inputs {
+          is_optional
           input {
             id
             label

--- a/src/queries/thread/get.graphql
+++ b/src/queries/thread/get.graphql
@@ -46,6 +46,7 @@ query get_thread($id: String!) {
                     }
                 }
                 inputs {
+                    is_optional
                     input {
                         id
                         label

--- a/src/screens/modeling/thread/mint-datasets.ts
+++ b/src/screens/modeling/thread/mint-datasets.ts
@@ -1160,6 +1160,7 @@ ${latest_data_event?.notes ? latest_data_event.notes : ""}</textarea
           });
 
           if (
+            !input.isOptional &&
             model_ensembles[modelid].bindings[inputid].length == 0 &&
             model_dt_ensembles[modelid].bindings[inputid].length == 0
           ) {

--- a/src/screens/modeling/thread/mint-datasets.ts
+++ b/src/screens/modeling/thread/mint-datasets.ts
@@ -1110,6 +1110,7 @@ ${latest_data_event?.notes ? latest_data_event.notes : ""}</textarea
       this.thread.model_dt_ensembles || {};
 
     let allok = true;
+    console.groupCollapsed("[mint-datasets] _selectThreadDatasets gating");
     Object.keys(this.thread.models!).map((modelid) => {
       let model = this.thread.models![modelid];
       let ok = true;
@@ -1127,6 +1128,9 @@ ${latest_data_event?.notes ? latest_data_event.notes : ""}</textarea
             current_data_ensemble &&
             current_data_ensemble.length > 0
           ) {
+            console.log(
+              `[mint-datasets] skip pre-bound input model=${model.name} input=${input.name} isOptional=${!!input.isOptional} preBindings=${current_data_ensemble.length}`
+            );
             return;
           }
 
@@ -1159,18 +1163,26 @@ ${latest_data_event?.notes ? latest_data_event.notes : ""}</textarea
             data_transformations[dtid] = new_datatransformations[dtid];
           });
 
-          if (
-            !input.isOptional &&
-            model_ensembles[modelid].bindings[inputid].length == 0 &&
-            model_dt_ensembles[modelid].bindings[inputid].length == 0
-          ) {
+          const dsCount = model_ensembles[modelid].bindings[inputid].length;
+          const dtCount = model_dt_ensembles[modelid].bindings[inputid].length;
+          const empty = dsCount === 0 && dtCount === 0;
+          const blocks = empty && !input.isOptional;
+          if (blocks) {
             ok = false;
           }
+          console.log(
+            `[mint-datasets] input model=${model.name} input=${input.name} isOptional=${!!input.isOptional} datasets=${dsCount} dts=${dtCount} empty=${empty} blocks=${blocks}`
+          );
         });
       if (!ok) {
         allok = false;
       }
+      console.log(
+        `[mint-datasets] model summary model=${model.name} ok=${ok}`
+      );
     });
+    console.log(`[mint-datasets] allok=${allok}`);
+    console.groupEnd();
 
     if (!allok) {
       this._waiting = false;

--- a/src/screens/modeling/thread/mint-datasets.ts
+++ b/src/screens/modeling/thread/mint-datasets.ts
@@ -392,8 +392,11 @@ export class MintDatasets extends connect(store)(MintThreadPage) {
                               });
                               return html`
                                 <li>
+                                  ${input.isOptional
+                                    ? html`<wl-icon style="color: #999; font-size:16px; vertical-align:middle; margin-right:4px;" title="Optional input — selection not required">info</wl-icon>`
+                                    : html`<wl-icon style="color: orange; font-size:16px; vertical-align:middle; margin-right:4px;">warning</wl-icon>`}
                                   Select an input dataset for
-                                  <b>${input.name}</b>. (You can select more
+                                  <b>${input.name}</b>${input.isOptional ? html` <span style="color:#999; font-size:0.85em;">(optional)</span>` : ""}. (You can select more
                                   than one dataset if you want several runs).
                                   Datasets matching the driving variable specied
                                   (if any) are in <b>bold</b>.

--- a/src/screens/modeling/thread/thread-expansion-datasets.ts
+++ b/src/screens/modeling/thread/thread-expansion-datasets.ts
@@ -175,6 +175,7 @@ export class ThreadExpansionDatasets extends ThreadExpansion {
     let done: boolean = true;
     Object.values(this.thread.models).forEach((m: LocalModel) => {
       (m.input_files || []).forEach((input: ModelIO) => {
+        if (input.isOptional) return;
         if (!input.value) {
           let allBindings: ModelIOBindings =
             this.thread.model_ensembles![m.id].bindings || {};
@@ -334,6 +335,7 @@ export class ThreadExpansionDatasets extends ThreadExpansion {
       (fixedInputs.length + reqInputs.length == model.input_files.length &&
         reqInputs.every(
           (input: ModelIO) =>
+            input.isOptional ||
             (this.modifiedInputs[input.id] &&
               this.modifiedInputs[input.id].length > 0) ||
             (modelBindings[input.id] || []).map(
@@ -442,14 +444,23 @@ export class ThreadExpansionDatasets extends ThreadExpansion {
     input: ModelIO
   ): TemplateResult {
     let dataslices: Dataslice[] = this.modifiedInputs[input.id];
+    let hasSelection: boolean = !!(dataslices && dataslices.length > 0);
     return html`
       <tr>
         <td>
           <div style="display:flex; align-items:center;">
-            ${dataslices && dataslices.length > 0
+            ${hasSelection
               ? html`
                   <wl-icon style="color: 'green'; margin-right: 5px;"
                     >done</wl-icon
+                  >
+                `
+              : input.isOptional
+              ? html`
+                  <wl-icon
+                    style="color: #999; margin-right: 5px;"
+                    title="Optional input — selection not required"
+                    >info</wl-icon
                   >
                 `
               : html`
@@ -457,7 +468,9 @@ export class ThreadExpansionDatasets extends ThreadExpansion {
                     >warning</wl-icon
                   >
                 `}
-            ${input.name}
+            ${input.name}${input.isOptional && !hasSelection
+              ? html`<span style="color:#999; margin-left:6px; font-size:0.85em;">(optional)</span>`
+              : ""}
           </div>
         </td>
         <td>

--- a/src/screens/models/reducers.ts
+++ b/src/screens/models/reducers.ts
@@ -64,6 +64,7 @@ export interface ModelIO extends IdNameObject {
   variables: string[];
   value?: Dataslice;
   position?: number;
+  isOptional?: boolean;
 }
 
 export interface ModelParameter extends IdNameObject {

--- a/src/util/graphql_adapter.ts
+++ b/src/util/graphql_adapter.ts
@@ -494,7 +494,12 @@ export const modelFromGQL = (m: any) => {
 
   m.input_files = (m["inputs"] ?? []).map((item: any) => {
     const io = item["input"] ?? item;
-    return { id: io["id"], name: io["label"] ?? io["name"], variables: [] } as ModelIO;
+    return {
+      id: io["id"],
+      name: io["label"] ?? io["name"],
+      variables: [],
+      isOptional: !!item["is_optional"],
+    } as ModelIO;
   });
   delete m["inputs"];
   m.output_files = (m["outputs"] ?? []).map((item: any) => {

--- a/src/util/state_functions.ts
+++ b/src/util/state_functions.ts
@@ -77,7 +77,7 @@ export const getThreadDatasetsStatus = (thread: Thread) => {
       let model = thread.models[modelid];
       let mensemble = thread.model_ensembles[modelid];
       model.input_files.forEach((input) => {
-        if (!input.value && !mensemble.bindings[input.id]) {
+        if (!input.value && !mensemble.bindings[input.id] && !input.isOptional) {
           ok = false;
         }
       });


### PR DESCRIPTION
## Summary

Thread datasets selection UI treated optional model inputs as required: orange warning icon, "None selected" gating model done state.

`is_optional` was wired through REST API (Phase 12-02/03/04) but the thread page reads via Apollo `get_thread` directly against Hasura, bypassing REST plumbing. Junction column was never selected, mapped, or rendered.

## Changes

- `queries/thread/get.graphql` + `get-subscription.graphql`: select `is_optional` on `modelcatalog_configuration_input` junction
- `util/graphql_adapter.ts`: map `item.is_optional` -> `ModelIO.isOptional`
- `screens/models/reducers.ts`: add `isOptional?: boolean` to `ModelIO`
- `screens/modeling/thread/thread-expansion-datasets.ts`:
  - `getStatus` skips optional inputs when computing done
  - `modelDone` short-circuits true on optional inputs
  - `renderRequiredDatasetRow` renders grey `info` icon + `(optional)` label instead of orange warning when optional and unselected

## Test plan

- [ ] Load thread with `hello world file input test` model
- [ ] Optional Input row shows grey info icon + "(optional)" suffix when nothing selected (not orange warning)
- [ ] Required Input row still shows orange warning when nothing selected
- [ ] Model header status no longer flags warning if only optional inputs are unset
- [ ] Selecting a dataset for the optional input still works (green check)
- [ ] Required input selection still gates model done state

## Follow-up

`mint-datasets.ts` has the same pattern — tracked in `.planning/todos/pending/2026-05-03-mint-datasets-optional-input-warning.md`.

Companion bump: dynamo PR https://github.com/In-For-Disaster-Analytics/dynamo/pull/6